### PR TITLE
Update/frontend hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,9 @@
 
-# undp account keys
-VITE_REDIRECT_URL=
-VITE_ACCESS_CODE=
+# Azure AD / backend API configuration
 VITE_CLIENT_ID=
 VITE_AUTHORITY=
 VITE_API_BASEURL=
 
-# Pexels API key
+# Optional integrations
 VITE_PEXEL_API_KEY=
-
-# World News API key
 VITE_WORLD_NEWS_API_KEY=

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -39,9 +39,9 @@ module.exports = {
     'jsx-a11y/click-events-have-key-events': 'warn',
     'jsx-a11y/no-static-element-interactions': 'warn',
     'react/no-array-index-key': 'off',
+    'react/prop-types': 'off',
     '@typescript-eslint/no-unused-vars': 'off',
     'react-hooks/exhaustive-deps': 'off',
     'react/no-unescaped-entities': 'off'
   }
 };
-

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,6 +37,7 @@
     "no-restricted-syntax": "off",
     "no-console": "off",
     "arrow-body-style": "off",
+    "react/prop-types": "off",
     "react/no-unused-prop-types": "off",
     "@typescript-eslint/no-shadow": "off",
     "@typescript-eslint/no-explicit-any": "off",

--- a/package.json
+++ b/package.json
@@ -87,12 +87,5 @@
     "vite": "^4.1.0",
     "vite-plugin-eslint": "^1.8.1",
     "vitest": "^3.0.7"
-  },
-  "vitest": {
-    "environment": "jsdom",
-    "globals": true,
-    "setupFiles": [
-      "./src/setupTests.ts"
-    ]
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -63,15 +63,22 @@ npm install
 
 To start the project locally, you can run `npm run dev` in the project folder in terminal or command prompt. This will run the app in development mode. Open [http://localhost:5173/](http://localhost:5173/) to view it in the browser. The page will reload if you make edits. You will also see any lint errors in the console.
 
-You will need a `.env.local` file in the root folder. the `env` file would require the following variable and values
+You will need a `.env.local` file in the root folder. The frontend currently reads these variables:
 
 ```
-VITE_API_LINK=https://signals-and-trends-api.azurewebsites.net/v1/
-VITE_ACCESS_CODE={{contact the team for API secret}}
-VITE_AUTHORITY=https://login.microsoftonline.com/{{contact the team for the complete URL}}
-VITE_CLIENT_ID={{contact the team forClient ID}}
+VITE_CLIENT_ID={{contact the team for the Azure AD app client ID}}
+VITE_AUTHORITY=https://login.microsoftonline.com/{{tenant-or-policy}}
 VITE_API_BASEURL=https://ftss-api-dev.azurewebsites.net/
 ```
+
+Optional integrations:
+
+```
+VITE_PEXEL_API_KEY={{optional, only needed for image search flows}}
+VITE_WORLD_NEWS_API_KEY={{optional, only needed for news enrichment flows}}
+```
+
+`VITE_CLIENT_SECRET` should not be present in the frontend. Client secrets belong on the server, not in a browser-delivered app.
 
 ### Tooling Setup
 
@@ -117,4 +124,3 @@ All changes must go through a pull request and code review. Changes are to be me
 7. **Open a Pull Request to `staging`**: Go to the original repository and click on "New Pull Request." Provide a detailed description of your changes and why they should be merged.
 
 When merging from `staging` to `main`, make sure to merge with rebase.
-

--- a/src/API/signalsCall.test.ts
+++ b/src/API/signalsCall.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { searchSignals } from './signalsCall';
+import { axiosInstance } from './apiConfig';
+
+vi.mock('./apiConfig', () => ({
+  axiosInstance: {
+    get: vi.fn(),
+    defaults: {
+      baseURL: 'http://localhost:8000',
+    },
+  },
+}));
+
+vi.mock('../logger', () => ({
+  default: {
+    debug: vi.fn(),
+  },
+}));
+
+describe('searchSignals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the expected default search params', async () => {
+    vi.mocked(axiosInstance.get).mockResolvedValueOnce({
+      data: {
+        current_page: 1,
+        per_page: 10,
+        total_pages: 1,
+        total_count: 0,
+        data: [],
+      },
+    });
+
+    const result = await searchSignals();
+
+    expect(axiosInstance.get).toHaveBeenCalledWith('/signals/search', {
+      params: {
+        page: 1,
+        per_page: 10,
+        order_by: 'created_at',
+        direction: 'desc',
+        statuses: ['Approved'],
+      },
+    });
+    expect(result).toEqual({
+      current_page: 1,
+      per_page: 10,
+      total_pages: 1,
+      total_count: 0,
+      data: [],
+    });
+  });
+
+  it('includes only the optional params that are provided', async () => {
+    vi.mocked(axiosInstance.get).mockResolvedValueOnce({
+      data: {
+        current_page: 2,
+        per_page: 20,
+        total_pages: 3,
+        total_count: 42,
+        data: [],
+      },
+    });
+
+    await searchSignals({
+      page: 2,
+      per_page: 20,
+      statuses: ['New'],
+      query: 'climate',
+      created_for: 'General scanning',
+      steep_secondary: ['Economic'],
+      score: 'High',
+    });
+
+    expect(axiosInstance.get).toHaveBeenCalledWith('/signals/search', {
+      params: {
+        page: 2,
+        per_page: 20,
+        order_by: 'created_at',
+        direction: 'desc',
+        statuses: ['New'],
+        created_for: 'General scanning',
+        steep_secondary: ['Economic'],
+        query: 'climate',
+        score: 'High',
+      },
+    });
+  });
+});

--- a/src/AddNew/AddNewSignalEl.tsx
+++ b/src/AddNew/AddNewSignalEl.tsx
@@ -24,31 +24,38 @@ export function AddNewSignalEl() {
   };
 
   return (
-    <div>
-    <div className='flex-wrap' style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-      <h3 className='undp-typography margin-top-05'>Add New Signal</h3>
-      <button
-        className='undp-button button-secondary'
-        type='button'
-        onClick={() => setShowExtractModal(true)}
+    <div className='signal-entry-page'>
+      <div
+        className='flex-wrap'
         style={{
           display: 'flex',
           alignItems: 'center',
-          gap: '0.5rem',
-          marginBottom: '1rem',
+          justifyContent: 'space-between',
         }}
       >
-        <svg width='16' height='16' viewBox='0 0 16 16' fill='none'>
-          <path
-            d='M8 2V8M8 8V14M8 8H14M8 8H2'
-            stroke='currentColor'
-            strokeWidth='2'
-            strokeLinecap='round'
-          />
-        </svg>
-        AI Extract  
-      </button>
-    </div>
+        <h3 className='undp-typography margin-top-05'>Add New Signal</h3>
+        <button
+          className='undp-button button-secondary'
+          type='button'
+          onClick={() => setShowExtractModal(true)}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem',
+            marginBottom: '1rem',
+          }}
+        >
+          <svg width='16' height='16' viewBox='0 0 16 16' fill='none'>
+            <path
+              d='M8 2V8M8 8V14M8 8H14M8 8H2'
+              stroke='currentColor'
+              strokeWidth='2'
+              strokeLinecap='round'
+            />
+          </svg>
+          AI Extract
+        </button>
+      </div>
 
       <SignalEntryFormEl draft={false} initialData={extractedData} />
 

--- a/src/AdminPanel/index.tsx
+++ b/src/AdminPanel/index.tsx
@@ -117,7 +117,7 @@ export function AdminPanel() {
         <div>
           <p className='undp-typography label'>Filter by roles</p>
           <Select
-            className='undp-select'
+            className='undp-select admin-panel-select'
             placeholder='Filter by role'
             onChange={e => {
               setFilterRole(e as 'All Roles' | 'Admin' | 'Curator' | 'User');

--- a/src/AdminPanel/index.tsx
+++ b/src/AdminPanel/index.tsx
@@ -90,7 +90,7 @@ export function AdminPanel() {
 
   return (
     <div
-      className='margin-top-13 padding-top-09 margin-bottom-09'
+      className='margin-bottom-09'
       style={{
         width: '100%',
         maxWidth: '64rem',

--- a/src/App.css
+++ b/src/App.css
@@ -4,7 +4,8 @@
     src: url('./assets/soehne-breit-web-dreiviertelfett.woff2') format('woff2');
 }
 
-h1.undp-typography {
+h1.undp-typography,
+.signal-analytics-dashboard h2.undp-typography {
     font-family: var(--fontFamilyHeadings) !important;
 }
 
@@ -304,4 +305,127 @@ h1.undp-typography {
   margin-top: 0 !important;
   padding-bottom: 0 !important;
   text-align: left;
+}
+
+.profile-unit-select.ant-select-single .ant-select-selector {
+  align-items: center !important;
+  display: flex;
+  justify-content: flex-start;
+  min-height: 3rem !important;
+  padding: 0 3rem 0 0.75rem !important;
+}
+
+.profile-unit-select.ant-select-single .ant-select-selection-item,
+.profile-unit-select.ant-select-single .ant-select-selection-placeholder,
+.profile-unit-select.ant-select-single .ant-select-selection-search {
+  align-items: center;
+  display: flex;
+  min-height: calc(3rem - 4px);
+  text-align: left;
+}
+
+.profile-unit-select.ant-select-single .ant-select-selection-item,
+.profile-unit-select.ant-select-single .ant-select-selection-placeholder {
+  padding: 0 3rem 0 0 !important;
+}
+
+.profile-unit-select.ant-select-single:not(.ant-select-customize-input)
+  .ant-select-selector
+  .ant-select-selection-search-input {
+  height: 100% !important;
+  margin-top: 0 !important;
+  padding-bottom: 0 !important;
+  text-align: left;
+}
+
+.undp-pagination-shell .undp-pagination {
+  align-items: center;
+  background: var(--white);
+  border: 2px solid var(--black);
+  border-radius: 0;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  padding: 0.75rem 1rem;
+}
+
+.undp-pagination-shell .undp-pagination .ant-pagination-options {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.75rem;
+  margin-inline-start: 0;
+  order: -1;
+}
+
+.undp-pagination-shell .undp-pagination .ant-select {
+  min-width: 8.5rem;
+}
+
+.undp-pagination-shell .undp-pagination .ant-select-selector,
+.undp-pagination-shell .undp-pagination .ant-pagination-item,
+.undp-pagination-shell .undp-pagination .ant-pagination-prev,
+.undp-pagination-shell .undp-pagination .ant-pagination-next {
+  border: 2px solid var(--black) !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+}
+
+.undp-pagination-shell .undp-pagination .ant-select-selector {
+  align-items: center !important;
+  display: flex;
+  min-height: 3rem !important;
+  padding: 0 2.5rem 0 0.75rem !important;
+}
+
+.undp-pagination-shell .undp-pagination .ant-select-selection-item,
+.undp-pagination-shell .undp-pagination .ant-select-selection-placeholder {
+  color: var(--black) !important;
+  display: flex;
+  font-family: var(--fontFamily);
+  font-size: 1rem;
+  font-weight: 400;
+}
+
+.undp-pagination-shell .undp-pagination .ant-pagination-options-size-changer {
+  margin-inline-end: 0;
+}
+
+.undp-pagination-shell .undp-pagination .ant-pagination-item,
+.undp-pagination-shell .undp-pagination .ant-pagination-prev,
+.undp-pagination-shell .undp-pagination .ant-pagination-next {
+  align-items: center;
+  background: var(--white);
+  display: inline-flex;
+  height: 3rem;
+  justify-content: center;
+  margin-inline-end: 0 !important;
+  min-width: 3rem;
+}
+
+.undp-pagination-shell .undp-pagination .ant-pagination-item a,
+.undp-pagination-shell .undp-pagination .ant-pagination-prev .ant-pagination-item-link,
+.undp-pagination-shell .undp-pagination .ant-pagination-next .ant-pagination-item-link {
+  align-items: center;
+  color: var(--black) !important;
+  display: inline-flex;
+  font-family: var(--fontFamilyHeadings);
+  font-size: 1rem;
+  justify-content: center;
+  min-height: 100%;
+  min-width: 100%;
+}
+
+.undp-pagination-shell .undp-pagination .ant-pagination-item-active {
+  background: var(--blue) !important;
+  border-color: var(--blue) !important;
+}
+
+.undp-pagination-shell .undp-pagination .ant-pagination-item-active a {
+  color: var(--white) !important;
+}
+
+.undp-pagination-shell .undp-pagination .ant-pagination-jump-prev,
+.undp-pagination-shell .undp-pagination .ant-pagination-jump-next {
+  margin-inline-end: 0 !important;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -41,3 +41,172 @@ h1.undp-typography {
   margin-top: 8rem;
   overflow-x: hidden;
 }
+
+:where(.signals-page, .signal-entry-page, .signals-filter-modal)
+  .undp-select.ant-select-single
+  .ant-select-selector {
+  display: flex;
+  align-items: center !important;
+  justify-content: flex-start;
+  padding: 0 3rem 0 0.75rem !important;
+}
+
+:where(.signals-page, .signal-entry-page, .signals-filter-modal)
+  .undp-select
+  .ant-select-selector {
+  align-items: center !important;
+}
+
+:where(.signals-page, .signal-entry-page, .signals-filter-modal)
+  .undp-select.ant-select-single.ant-select-show-search
+  .ant-select-selector,
+:where(.signals-page, .signal-entry-page, .signals-filter-modal)
+  .undp-select.ant-select-single.ant-select-show-search
+  .ant-select-selector
+  .ant-select-selection-item,
+:where(.signals-page, .signal-entry-page, .signals-filter-modal)
+  .undp-select.ant-select-single.ant-select-show-search
+  .ant-select-selector
+  .ant-select-selection-placeholder {
+  padding-top: 0 !important;
+}
+
+:where(.signals-page, .signal-entry-page, .signals-filter-modal)
+  .undp-select.ant-select-single
+  .ant-select-selection-item,
+:where(.signals-page, .signal-entry-page, .signals-filter-modal)
+  .undp-select.ant-select-single
+  .ant-select-selection-placeholder,
+:where(.signals-page, .signal-entry-page, .signals-filter-modal)
+  .undp-select.ant-select-single
+  .ant-select-selection-search {
+  display: flex;
+  align-items: center;
+  min-height: calc(3rem - 4px);
+}
+
+:where(.signals-page, .signal-entry-page, .signals-filter-modal)
+  .undp-select.ant-select-single
+  .ant-select-selection-item,
+:where(.signals-page, .signal-entry-page, .signals-filter-modal)
+  .undp-select.ant-select-single
+  .ant-select-selection-placeholder {
+  width: 100%;
+  padding: 0 3rem 0 0 !important;
+  text-align: left;
+}
+
+:where(.signals-page, .signal-entry-page, .signals-filter-modal)
+  .undp-select
+  .ant-select-selection-search,
+:where(.signals-page, .signal-entry-page, .signals-filter-modal)
+  .undp-select
+  .ant-select-selection-search-input {
+  text-align: left;
+}
+
+:where(.signals-page, .signal-entry-page, .signals-filter-modal)
+  .undp-select.ant-select-single:not(.ant-select-customize-input)
+  .ant-select-selector
+  .ant-select-selection-search-input {
+  height: 100% !important;
+  margin-top: 0 !important;
+  padding-bottom: 0 !important;
+}
+
+:where(.signals-page, .signal-entry-page, .signals-filter-modal)
+  .undp-select.ant-select-multiple
+  .ant-select-selector {
+  display: flex;
+  align-items: center !important;
+  justify-content: flex-start;
+  padding-top: 0.375rem !important;
+  padding-bottom: 0.375rem !important;
+}
+
+:where(.signals-page, .signal-entry-page, .signals-filter-modal)
+  .undp-select.ant-select-multiple
+  .ant-select-selection-overflow {
+  align-items: center;
+  column-gap: 0.375rem;
+  justify-content: flex-start;
+  row-gap: 0.375rem;
+}
+
+:where(.signals-page, .signal-entry-page, .signals-filter-modal)
+  .undp-select.ant-select-multiple
+  .ant-select-selection-search {
+  display: flex;
+  align-items: center;
+}
+
+:where(.signals-page, .signal-entry-page, .signals-filter-modal)
+  .undp-select.ant-select-multiple
+  .ant-select-selection-item,
+:where(.signals-page, .signal-entry-page, .signals-filter-modal)
+  .undp-select.ant-select-multiple
+  .ant-select-selection-placeholder,
+:where(.signals-page, .signal-entry-page, .signals-filter-modal)
+  .undp-select.ant-select-multiple
+  .ant-select-selection-item-content {
+  text-align: left;
+}
+
+:where(.signals-page, .signal-entry-page)
+  .undp-button.button-primary,
+:where(.signals-page, .signal-entry-page)
+  .undp-button.button-secondary {
+  min-height: 3.25rem;
+  border-radius: 0;
+}
+
+:where(.signals-page, .signal-entry-page)
+  .undp-button.ant-btn.button-primary,
+:where(.signals-page, .signal-entry-page)
+  .undp-button.ant-btn.button-secondary {
+  height: auto;
+  padding: 1rem 1.5rem;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.signal-entry-page .signal-entry-multi-select.ant-select-multiple .ant-select-selector {
+  align-items: center !important;
+  display: flex;
+  min-height: 3rem !important;
+  padding: 0.375rem 0.75rem !important;
+}
+
+.signal-entry-page
+  .signal-entry-multi-select.ant-select-multiple
+  .ant-select-selection-overflow {
+  align-items: center !important;
+  display: flex;
+  min-height: calc(3rem - 0.75rem);
+}
+
+.signal-entry-page
+  .signal-entry-multi-select.ant-select-multiple
+  .ant-select-selection-overflow-item,
+.signal-entry-page
+  .signal-entry-multi-select.ant-select-multiple
+  .ant-select-selection-search {
+  align-items: center;
+  display: flex;
+}
+
+.signal-entry-page
+  .signal-entry-multi-select.ant-select-multiple
+  .ant-select-selection-placeholder {
+  align-items: center;
+  display: flex;
+  min-height: 1.5rem;
+  text-align: left;
+}
+
+.signal-entry-page
+  .signal-entry-multi-select.ant-select-multiple
+  .ant-select-selection-search-input {
+  height: 1.5rem !important;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -429,3 +429,97 @@ h1.undp-typography,
 .undp-pagination-shell .undp-pagination .ant-pagination-jump-next {
   margin-inline-end: 0 !important;
 }
+
+.unified-bubble-container {
+  background: transparent !important;
+  border: 0 !important;
+  border-radius: 1rem !important;
+  box-shadow: none !important;
+  height: auto !important;
+  overflow: visible !important;
+  transition: none !important;
+  width: auto !important;
+}
+
+.unified-bubble-container:hover {
+  transform: none !important;
+}
+
+.chat-bubble {
+  align-items: center;
+  background-color: var(--blue-600);
+  border: 0;
+  border-radius: 50%;
+  box-shadow: 0 10px 24px rgba(0, 85, 164, 0.22);
+  color: var(--white);
+  cursor: pointer;
+  display: inline-flex;
+  justify-content: center;
+  min-height: 4rem;
+  min-width: 4rem;
+  padding: 1rem;
+  transition: none !important;
+  white-space: nowrap;
+}
+
+.chat-bubble:hover,
+.chat-bubble:focus,
+.chat-bubble:active {
+  background-color: var(--blue-600);
+  box-shadow: 0 10px 24px rgba(0, 85, 164, 0.22);
+  color: var(--white);
+  outline: none;
+  transform: none !important;
+}
+
+.chat-bubble:focus-visible {
+  box-shadow:
+    0 0 0 3px rgba(255, 255, 255, 0.9),
+    0 0 0 6px rgba(0, 85, 164, 0.35);
+}
+
+.chat-bubble-icon {
+  align-items: center;
+  display: inline-flex;
+  flex-shrink: 0;
+  height: 2rem;
+  justify-content: center;
+  width: 2rem;
+}
+
+.chat-bubble-icon svg {
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+
+.raggle-chat-expanded .unified-bubble-container,
+.raggle-chat-fullscreen .unified-bubble-container {
+  align-items: center;
+  background-color: var(--blue-600) !important;
+  border-radius: 50% !important;
+  box-shadow: 0 10px 24px rgba(0, 85, 164, 0.22) !important;
+  display: inline-flex !important;
+  height: 3rem !important;
+  justify-content: center;
+  min-width: 3rem !important;
+  padding: 0 !important;
+  position: relative;
+}
+
+.raggle-chat-expanded .unified-bubble-container img[src*='caret-down.png'],
+.raggle-chat-fullscreen .unified-bubble-container img[src*='caret-down.png'] {
+  display: none !important;
+}
+
+.raggle-chat-expanded .unified-bubble-container::before,
+.raggle-chat-fullscreen .unified-bubble-container::before {
+  border-bottom: 2px solid var(--white);
+  border-right: 2px solid var(--white);
+  content: '';
+  display: block;
+  height: 0.75rem;
+  margin-top: -0.125rem;
+  transform: rotate(45deg);
+  width: 0.75rem;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -210,3 +210,98 @@ h1.undp-typography {
   .ant-select-selection-search-input {
   height: 1.5rem !important;
 }
+
+.trend-entry-select.ant-select-single .ant-select-selector {
+  align-items: center !important;
+  display: flex;
+  justify-content: flex-start;
+  min-height: 3rem !important;
+  padding: 0 3rem 0 0.75rem !important;
+}
+
+.trend-entry-select.ant-select-single .ant-select-selection-item,
+.trend-entry-select.ant-select-single .ant-select-selection-placeholder,
+.trend-entry-select.ant-select-single .ant-select-selection-search {
+  align-items: center;
+  display: flex;
+  min-height: calc(3rem - 4px);
+  text-align: left;
+}
+
+.trend-entry-select.ant-select-single .ant-select-selection-item,
+.trend-entry-select.ant-select-single .ant-select-selection-placeholder {
+  padding: 0 3rem 0 0 !important;
+}
+
+.trend-entry-select.ant-select-single:not(.ant-select-customize-input)
+  .ant-select-selector
+  .ant-select-selection-search-input {
+  height: 100% !important;
+  margin-top: 0 !important;
+  padding-bottom: 0 !important;
+  text-align: left;
+}
+
+.trend-entry-multi-select.ant-select-multiple .ant-select-selector {
+  align-items: center !important;
+  display: flex;
+  min-height: 3rem !important;
+  padding: 0.375rem 0.75rem !important;
+}
+
+.trend-entry-multi-select.ant-select-multiple .ant-select-selection-overflow {
+  align-items: center !important;
+  column-gap: 0.375rem;
+  display: flex;
+  min-height: calc(3rem - 0.75rem);
+  row-gap: 0.375rem;
+}
+
+.trend-entry-multi-select.ant-select-multiple .ant-select-selection-overflow-item,
+.trend-entry-multi-select.ant-select-multiple .ant-select-selection-search,
+.trend-entry-multi-select.ant-select-multiple .ant-select-selection-placeholder {
+  align-items: center;
+  display: flex;
+}
+
+.trend-entry-multi-select.ant-select-multiple .ant-select-selection-placeholder,
+.trend-entry-multi-select.ant-select-multiple .ant-select-selection-item,
+.trend-entry-multi-select.ant-select-multiple .ant-select-selection-item-content,
+.trend-entry-multi-select.ant-select-multiple .ant-select-selection-search-input {
+  text-align: left;
+}
+
+.trend-entry-multi-select.ant-select-multiple .ant-select-selection-search-input {
+  height: 1.5rem !important;
+}
+
+.admin-panel-select.ant-select-single .ant-select-selector {
+  align-items: center !important;
+  display: flex;
+  justify-content: flex-start;
+  min-height: 3rem !important;
+  padding: 0 3rem 0 0.75rem !important;
+}
+
+.admin-panel-select.ant-select-single .ant-select-selection-item,
+.admin-panel-select.ant-select-single .ant-select-selection-placeholder,
+.admin-panel-select.ant-select-single .ant-select-selection-search {
+  align-items: center;
+  display: flex;
+  min-height: calc(3rem - 4px);
+  text-align: left;
+}
+
+.admin-panel-select.ant-select-single .ant-select-selection-item,
+.admin-panel-select.ant-select-single .ant-select-selection-placeholder {
+  padding: 0 3rem 0 0 !important;
+}
+
+.admin-panel-select.ant-select-single:not(.ant-select-customize-input)
+  .ant-select-selector
+  .ant-select-selection-search-input {
+  height: 100% !important;
+  margin-top: 0 !important;
+  padding-bottom: 0 !important;
+  text-align: left;
+}

--- a/src/AuthConfig.ts
+++ b/src/AuthConfig.ts
@@ -1,10 +1,9 @@
-import { CLIENT_ID, CLIENT_SECRET, AUTHORITY } from './Constants';
+import { CLIENT_ID, AUTHORITY } from './Constants';
 
 export const msalConfig = {
   auth: {
     clientId: CLIENT_ID as string,
     authority: AUTHORITY as string,
-    clientSecret: CLIENT_SECRET as string,
     redirectUri: '/',
     postLogoutRedirectUri: '/',
     navigateToLoginRequestUrl: false,

--- a/src/Components/AdminRoute.test.tsx
+++ b/src/Components/AdminRoute.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import Context from '../Context/Context';
+import type { CtxDataType } from '../Types';
+import { AdminRoute } from './AdminRoute';
+
+function renderAdminRoute(isAdmin: boolean) {
+  const contextValue = {
+    isAdmin,
+  } as CtxDataType;
+
+  return render(
+    <Context.Provider value={contextValue}>
+      <MemoryRouter
+        initialEntries={['/admin']}
+        future={{
+          v7_startTransition: true,
+          v7_relativeSplatPath: true,
+        }}
+      >
+        <Routes>
+          <Route path="/" element={<div>Home page</div>} />
+          <Route
+            path="/admin"
+            element={(
+              <AdminRoute>
+                <div>Admin content</div>
+              </AdminRoute>
+            )}
+          />
+        </Routes>
+      </MemoryRouter>
+    </Context.Provider>,
+  );
+}
+
+describe('AdminRoute', () => {
+  it('renders protected content for admins', () => {
+    renderAdminRoute(true);
+
+    expect(screen.getByText('Admin content')).toBeInTheDocument();
+  });
+
+  it('redirects non-admin users to the home page', () => {
+    renderAdminRoute(false);
+
+    expect(screen.getByText('Home page')).toBeInTheDocument();
+    expect(screen.queryByText('Admin content')).not.toBeInTheDocument();
+  });
+});

--- a/src/Components/ChatIcon.tsx
+++ b/src/Components/ChatIcon.tsx
@@ -1,8 +1,8 @@
 export function ChatIcon() {
   return (
     <svg
-      width="32"
-      height="32"
+      width="48"
+      height="48"
       viewBox="0 0 32 32"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/src/Components/MemberSelect.css
+++ b/src/Components/MemberSelect.css
@@ -35,7 +35,7 @@
 .member-select .ant-select-selector {
   border: 2px solid #000000 !important;
   border-radius: 0 !important;
-  padding: 0.375rem 0.75rem !important;
+  padding: 0 0.75rem !important;
   min-height: 3.25rem !important;
   display: flex;
   align-items: center !important;
@@ -56,20 +56,39 @@
 
 .member-select .ant-select-selection-placeholder {
   color: rgba(0, 0, 0, 0.25) !important;
-  inset-inline-start: 0.75rem !important;
-  inset-inline-end: 2.5rem !important;
+  display: flex !important;
+  align-items: center;
+  justify-content: flex-start !important;
   inset-block-start: 50% !important;
+  inset-inline-end: auto !important;
+  inset-inline-start: 0.75rem !important;
   line-height: 1.4 !important;
   margin: 0 !important;
   padding: 0 !important;
-  position: absolute;
+  position: absolute !important;
   text-align: left;
-  transform: translateY(-50%);
+  transform: translateY(-50%) !important;
+  width: calc(100% - 2.5rem) !important;
   font-size: 16px !important;
 }
 
 .member-select .ant-select-selection-overflow {
   align-items: center !important;
+  justify-content: flex-start;
+  min-height: calc(3.25rem - 4px);
+}
+
+.member-select .ant-select-selection-overflow-item,
+.member-select .ant-select-selection-overflow-item-suffix,
+.member-select .ant-select-selection-search {
+  align-items: center;
+  display: flex;
+  justify-content: flex-start;
+}
+
+.member-select .ant-select-selection-search-input {
+  height: 1.5rem !important;
+  margin: 0 !important;
 }
 
 .member-select .ant-select-selection-item {

--- a/src/Components/MemberSelect.css
+++ b/src/Components/MemberSelect.css
@@ -35,11 +35,12 @@
 .member-select .ant-select-selector {
   border: 2px solid #000000 !important;
   border-radius: 0 !important;
-  padding: 4px 8px !important;
-  min-height: 42px !important;
+  padding: 0.375rem 0.75rem !important;
+  min-height: 3.25rem !important;
   display: flex;
-  align-items: center;
+  align-items: center !important;
   flex-wrap: wrap !important;
+  position: relative;
 }
 
 .admin-select-input .ant-select-selector {
@@ -48,13 +49,27 @@
 }
 
 .member-select .ant-select-selection-search {
+  align-items: center;
+  display: flex;
   margin-inline-start: 0 !important;
 }
 
 .member-select .ant-select-selection-placeholder {
   color: rgba(0, 0, 0, 0.25) !important;
-  padding: 0 4px !important;
+  inset-inline-start: 0.75rem !important;
+  inset-inline-end: 2.5rem !important;
+  inset-block-start: 50% !important;
+  line-height: 1.4 !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  position: absolute;
+  text-align: left;
+  transform: translateY(-50%);
   font-size: 16px !important;
+}
+
+.member-select .ant-select-selection-overflow {
+  align-items: center !important;
 }
 
 .member-select .ant-select-selection-item {

--- a/src/Components/MemberSelect.tsx
+++ b/src/Components/MemberSelect.tsx
@@ -1,6 +1,5 @@
 import { useState, useContext } from 'react';
 import { Form, Input, Select, message } from 'antd';
-import PropTypes from 'prop-types';
 import { useQuery } from '@tanstack/react-query';
 import { searchUsers } from '../API/userCalls';
 import './MemberSelect.css';
@@ -122,28 +121,3 @@ const MemberSelect: React.FC<MemberSelectProps> = ({
 };
 
 export default MemberSelect;
-
-// Moved PropTypes definition after component definition
-// Commenting out PropTypes for now to address complex type issue later
-/*
-MemberSelect.propTypes = {
-  value: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.string),
-    PropTypes.arrayOf(
-      PropTypes.shape({
-        id: PropTypes.number.isRequired,
-        created_at: PropTypes.string.isRequired,
-        email: PropTypes.string.isRequired,
-        role: PropTypes.string.isRequired,
-        name: PropTypes.string.isRequired,
-        unit: PropTypes.string,
-        acclab: PropTypes.bool,
-      })
-    ),
-  ]),
-  onChange: PropTypes.func,
-  placeholder: PropTypes.string,
-  isAdminSelect: PropTypes.bool,
-  label: PropTypes.string,
-};
-*/

--- a/src/Components/PexelsImagePicker.tsx
+++ b/src/Components/PexelsImagePicker.tsx
@@ -126,25 +126,21 @@ const PexelsLogo = styled.img`
   margin-bottom: 8px;
 `;
 
-const SearchInput = styled.input`
-  padding: 8px 12px;
-  border: 1px solid var(--gray-400);
-  border-radius: 4px;
-  font-size: 0.875rem;
+const SearchInput = styled.input.attrs({
+  className: 'undp-input',
+})`
+  box-sizing: border-box;
   flex-grow: 1;
-  margin-right: 0.5rem;
-  
-  &:focus {
-    outline: none;
-    border-color: var(--blue-500);
-    box-shadow: 0 0 0 2px rgba(0, 127, 255, 0.2);
-  }
+  height: 3.25rem;
+  margin: 0;
+  width: 100%;
 `;
 
 const SearchContainer = styled.div`
   display: flex;
   align-items: center;
   margin-bottom: 1rem;
+  width: 100%;
 `;
 
 const MainButton = styled.button`
@@ -156,7 +152,7 @@ const MainButton = styled.button`
   font-weight: 500;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   width: 100%;
   margin-bottom: 1rem;
   
@@ -329,7 +325,7 @@ export function PexelsImagePicker({ query, onImageSelect }: Props) {
           <SearchContainer>
             <SearchInput
               type="text"
-              placeholder="Search for images..."
+              placeholder="Search Images..."
               value={searchQuery}
               onChange={handleSearchInputChange}
               disabled={isLoading}

--- a/src/Components/SignOutButton.tsx
+++ b/src/Components/SignOutButton.tsx
@@ -403,7 +403,7 @@ export function SignOutButton(props: Props) {
           >
             <p className='undp-typography margin-bottom-02'>Unit</p>
             <Select
-              className='undp-select margin-bottom-05'
+              className='undp-select margin-bottom-05 profile-unit-select'
               placeholder='Select a unit'
               onChange={e => {
                 setSelectedUnit(e);

--- a/src/Components/SignalAnalytics/GeographicDistribution.tsx
+++ b/src/Components/SignalAnalytics/GeographicDistribution.tsx
@@ -6,27 +6,34 @@ interface GeographicDistributionProps {
   totalSignals: number;
 }
 
-const GeoTooltip = (totalSignals: number) => ({ active, payload }: any) => {
-  if (active && payload && payload.length) {
-    return (
-      <div style={{
-        backgroundColor: 'white',
-        padding: '0.5rem',
-        border: '1px solid #ccc',
-        borderRadius: '4px',
-        boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
-        color: 'black',
-      }}>
-        <p className="undp-typography small-font" style={{ fontWeight: 'bold', color: 'black' }}>
-          {payload[0].name}
-        </p>
-        <p className="undp-typography small-font" style={{ color: 'black' }}>
-          Signals: {payload[0].value} ({((payload[0].value / totalSignals) * 100).toFixed(1)}%)
-        </p>
-      </div>
-    );
-  }
-  return null;
+const createGeoTooltip = (totalSignals: number) => {
+  const GeoTooltipContent = ({ active, payload }: any) => {
+    if (active && payload && payload.length) {
+      return (
+        <div style={{
+          backgroundColor: 'white',
+          padding: '0.5rem',
+          border: '1px solid #ccc',
+          borderRadius: '4px',
+          boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+          color: 'black',
+        }}>
+          <p className="undp-typography small-font" style={{ fontWeight: 'bold', color: 'black' }}>
+            {payload[0].name}
+          </p>
+          <p className="undp-typography small-font" style={{ color: 'black' }}>
+            Signals: {payload[0].value} ({((payload[0].value / totalSignals) * 100).toFixed(1)}%)
+          </p>
+        </div>
+      );
+    }
+
+    return null;
+  };
+
+  GeoTooltipContent.displayName = 'GeoTooltipContent';
+
+  return GeoTooltipContent;
 };
 
 function GeographicDistribution({ locationData, totalSignals }: GeographicDistributionProps) {
@@ -34,7 +41,7 @@ function GeographicDistribution({ locationData, totalSignals }: GeographicDistri
     <ReusablePieChart
       data={locationData}
       title="Geographic Distribution"
-      tooltipFormatter={GeoTooltip(totalSignals)}
+      tooltipFormatter={createGeoTooltip(totalSignals)}
       maxItems={6}
     />
   );

--- a/src/Components/SignalAnalytics/MonthlyTimeline.tsx
+++ b/src/Components/SignalAnalytics/MonthlyTimeline.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
 
 interface MonthlyTimelineProps {
   timelineData: Array<{ month: string; count: number }>;
@@ -11,7 +11,6 @@ const MonthlyTimeline: React.FC<MonthlyTimelineProps> = ({ timelineData }) => {
       <h6 className="undp-typography margin-bottom-05">Signal Creation Timeline (Monthly)</h6>
       <ResponsiveContainer width="100%" height={400}>
         <AreaChart data={timelineData}>
-          <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="month" />
           <YAxis />
           <Tooltip />

--- a/src/Components/SignalEntryFormEl.tsx
+++ b/src/Components/SignalEntryFormEl.tsx
@@ -881,7 +881,7 @@ export function SignalEntryFormEl(props: Props) {
               Secondary Locations
             </p>
             <Select
-              className='undp-select'
+              className='undp-select signal-entry-multi-select'
               placeholder='Select secondary locations'
               mode='multiple'
               maxTagCount='responsive'
@@ -961,7 +961,7 @@ export function SignalEntryFormEl(props: Props) {
         <div style={{ width: '100%' }} className='margin-bottom-07'>
           <p className='undp-typography margin-bottom-01'>Secondary STEEP+V</p>
           <Select
-            className='undp-select'
+            className='undp-select signal-entry-multi-select'
             placeholder='Select STEEP+V'
             mode='multiple'
             maxTagCount='responsive'
@@ -1128,7 +1128,7 @@ export function SignalEntryFormEl(props: Props) {
             Additional Signature Solution/Enabler
           </p>
           <Select
-            className='undp-select'
+            className='undp-select signal-entry-multi-select'
             placeholder='Select Signature Solution'
             onChange={e => {
               if (e.length > 1) {
@@ -1167,7 +1167,7 @@ export function SignalEntryFormEl(props: Props) {
         <p className='undp-typography margin-bottom-01'>SDGs*</p>
         <Select
           id='signal-sdgs'
-          className='undp-select'
+          className='undp-select signal-entry-multi-select'
           mode='multiple'
           placeholder='Select SDG'
           maxTagCount='responsive'
@@ -1399,6 +1399,7 @@ export function SignalEntryFormEl(props: Props) {
                 });
               }}
               placeholder='Select sprints to add this signal to'
+              className='undp-select signal-entry-multi-select'
             />
           </div>
         </SprintSection>

--- a/src/Components/SignalEntryFormEl.tsx
+++ b/src/Components/SignalEntryFormEl.tsx
@@ -313,17 +313,23 @@ const ValidationMessage = ({
       </p>
       <ul style={{ margin: 0, paddingLeft: '20px' }}>
         {errorMessages.map((message, index) => (
-          <li
-            key={index}
-            className='undp-typography'
-            style={{
-              color: 'var(--blue-700)',
-              cursor: 'pointer',
-              textDecoration: 'underline',
-            }}
-            onClick={() => handleErrorClick(fieldIds[invalidFields[index]])}
-          >
-            {message}
+          <li key={index}>
+            <button
+              type='button'
+              className='undp-typography'
+              style={{
+                color: 'var(--blue-700)',
+                cursor: 'pointer',
+                textDecoration: 'underline',
+                background: 'none',
+                border: 'none',
+                padding: 0,
+                font: 'inherit',
+              }}
+              onClick={() => handleErrorClick(fieldIds[invalidFields[index]])}
+            >
+              {message}
+            </button>
           </li>
         ))}
       </ul>

--- a/src/Components/SignalViews/SignalsList.tsx
+++ b/src/Components/SignalViews/SignalsList.tsx
@@ -106,9 +106,9 @@ export const SignalsList: React.FC<SignalsListProps> = ({
   // If there are no signals and we're not loading, show empty state
   if (!loading && (!signals || signals.length === 0)) {
     return (
-      <div className="margin-top-05">
+      <div>
         {title && (
-          <h3 className="undp-typography margin-top-05">{title}</h3>
+          <h3 className="undp-typography margin-top-00 margin-bottom-05">{title}</h3>
         )}
         <EmptyStateContainer>
           <Empty
@@ -128,9 +128,9 @@ export const SignalsList: React.FC<SignalsListProps> = ({
   }
 
   return (
-    <div className="margin-top-05">
+    <div>
       {title && (
-        <h3 className="undp-typography margin-top-05">{title}</h3>
+        <h3 className="undp-typography margin-top-00 margin-bottom-05">{title}</h3>
       )}
 
       {loading ? (

--- a/src/Components/SmartExtractModal.tsx
+++ b/src/Components/SmartExtractModal.tsx
@@ -45,10 +45,27 @@ export function SmartExtractModal({ isOpen, onClose, onExtract }: SmartExtractMo
         justifyContent: 'center',
         zIndex: 1000
       }}
-      onClick={handleClose}
     >
-      <div
+      <button
+        type="button"
+        aria-label="Close extract signal dialog"
+        onClick={handleClose}
         style={{
+          position: 'absolute',
+          inset: 0,
+          backgroundColor: 'rgba(0, 0, 0, 0.5)',
+          border: 'none',
+          padding: 0,
+          cursor: 'pointer'
+        }}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Extract signal"
+        style={{
+          position: 'relative',
+          zIndex: 1,
           backgroundColor: 'white',
           borderRadius: '8px',
           boxShadow: '0 4px 24px rgba(0, 0, 0, 0.15)',
@@ -57,7 +74,6 @@ export function SmartExtractModal({ isOpen, onClose, onExtract }: SmartExtractMo
           maxHeight: '80vh',
           overflow: 'auto'
         }}
-        onClick={(e) => e.stopPropagation()}
       >
         <div
           style={{

--- a/src/Components/TrendEntryFormEl.tsx
+++ b/src/Components/TrendEntryFormEl.tsx
@@ -313,7 +313,7 @@ export function TrendEntryFormEl(props: Props) {
         >
           <p className='undp-typography margin-bottom-01'>Time Horizon*</p>
           <Select
-            className='undp-select'
+            className='undp-select trend-entry-select'
             placeholder='Select time horizon'
             onChange={e => {
               updateTrendData({
@@ -339,7 +339,7 @@ export function TrendEntryFormEl(props: Props) {
         >
           <p className='undp-typography margin-bottom-01'>Impact Rating*</p>
           <Select
-            className='undp-select'
+            className='undp-select trend-entry-select'
             placeholder='Select impact rating'
             onChange={e => {
               updateTrendData({
@@ -446,7 +446,7 @@ export function TrendEntryFormEl(props: Props) {
           <div style={{ width: 'calc(50% - 0.5rem)' }}>
             <p className='undp-typography margin-bottom-01'>Primary STEEP+V*</p>
             <Select
-              className='undp-select'
+              className='undp-select trend-entry-select'
               placeholder='Select STEEP+V'
               onChange={e => {
                 updateTrendData({
@@ -468,7 +468,7 @@ export function TrendEntryFormEl(props: Props) {
               Secondary STEEP+V
             </p>
             <Select
-              className='undp-select'
+              className='undp-select trend-entry-multi-select'
               placeholder='Select STEEP+V'
               mode='multiple'
               onChange={e => {
@@ -512,7 +512,7 @@ export function TrendEntryFormEl(props: Props) {
             Primary Signature Solution/Enabler*
           </p>
           <Select
-            className='undp-select'
+            className='undp-select trend-entry-select'
             placeholder='Select Signature Solution'
             onChange={e => {
               updateTrendData({
@@ -534,7 +534,7 @@ export function TrendEntryFormEl(props: Props) {
             Additional Signature Solution/Enabler
           </p>
           <Select
-            className='undp-select'
+            className='undp-select trend-entry-multi-select'
             placeholder='Select Signature Solution'
             onChange={e => {
               if (e.length > 1) {
@@ -572,7 +572,7 @@ export function TrendEntryFormEl(props: Props) {
       <div className='margin-bottom-07' style={{ width: '100%' }}>
         <p className='undp-typography margin-bottom-01'>SDGs*</p>
         <Select
-          className='undp-select'
+          className='undp-select trend-entry-multi-select'
           mode='multiple'
           placeholder='Select SDG'
           maxTagCount='responsive'
@@ -668,7 +668,7 @@ export function TrendEntryFormEl(props: Props) {
       <div className='margin-bottom-07'>
         <p className='undp-typography margin-bottom-01'>Created For</p>
         <Select
-          className='undp-select'
+          className='undp-select trend-entry-select'
           placeholder='Created For'
           onChange={e => {
             updateTrendData({

--- a/src/Components/UserGroups/UserGroupForm.tsx
+++ b/src/Components/UserGroups/UserGroupForm.tsx
@@ -111,7 +111,6 @@ const UserGroupForm: React.FC<UserGroupFormProps> = ({
         >
           <MemberSelect
             placeholder='Type a name or UNDP email to search and select users'
-            label='Group Members'
           />
         </Form.Item>
       </>

--- a/src/Components/UserGroups/UserGroupsList.tsx
+++ b/src/Components/UserGroups/UserGroupsList.tsx
@@ -1,5 +1,5 @@
 import { useContext, useState } from 'react';
-import { Modal, message, Empty, Typography, Badge } from 'antd';
+import { Modal, message, Empty, Typography } from 'antd';
 import { 
   DeleteOutlined, 
   EditOutlined, 
@@ -18,7 +18,6 @@ import type { MenuProps } from 'antd';
 import { SignalSearch } from '../SignalSearch';
 import { SignalHorizontalView } from '../SignalViews';
 import { HeroCard } from '../HeroCard';
-import { get } from 'http';
 
 interface UserWithNameAndEmail {
   name: string;
@@ -34,6 +33,7 @@ interface UserGroupsListProps {
   onEdit?: (group: UserGroupDataType) => void;
   onView?: (groupId: number) => void;
   userGroups?: UserGroupDataType[] | ExtendedUserGroupDataType[];
+  variant?: 'hero' | 'simple';
 }
 
 const { Text } = Typography;
@@ -53,10 +53,31 @@ const GroupCard = styled.div`
   width: 100%;
   max-width: 100%;
   overflow-x: hidden;
-  background-color: #FFFFFF;
-  border: 1px solid #E8E8E8;
-  border-radius: 4px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  background-color: #ffffff;
+  border: 1px solid #d4d6d8;
+  border-top: 6px solid var(--blue-600);
+  border-radius: 0;
+  box-shadow: none;
+
+  .hero-card {
+    box-shadow: none !important;
+    transform: none !important;
+    transition: background-color 0.2s ease;
+  }
+
+  .hero-card:hover {
+    box-shadow: none !important;
+    transform: none !important;
+  }
+
+  .hero-card:hover [class*='HeroImageEl'] {
+    filter: brightness(92%);
+  }
+
+  .hero-card h3,
+  .hero-card .ant-typography {
+    font-family: var(--fontFamilyHeadings) !important;
+  }
   
   a:hover {
     text-decoration: underline !important;
@@ -67,8 +88,8 @@ const InfoSection = styled.div`
   display: flex;
   flex-direction: row;
   gap: 16px;
-  margin-top: 12px;
-  padding: 0 20px 16px 20px;
+  margin-top: 0;
+  padding: 0 20px 20px 20px;
   align-items: center;
   flex-wrap: wrap;
 `;
@@ -76,18 +97,125 @@ const InfoSection = styled.div`
 const UserAvatarGroup = styled.div`
   display: flex;
   align-items: center;
-  padding: 4px 12px;
-  border-radius: 16px;
-  transition: background-color 0.3s ease;
-  background-color: #F5F5F5;
+  gap: 8px;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #d4d6d8;
+  border-radius: 0;
+  background-color: var(--gray-200);
   
   &:hover {
-    background-color: rgba(0, 110, 181, 0.1);
+    background-color: var(--gray-300);
+  }
+
+  .ant-typography {
+    color: var(--gray-700);
+    font-size: 0.875rem;
+    font-weight: 600;
+    margin: 0;
+    text-transform: uppercase;
   }
 `;
 
 const SignalAvatarGroup = styled(UserAvatarGroup)`
   margin: 0;
+`;
+
+const SimpleGroupCard = styled.a`
+  display: block;
+  width: 100%;
+  color: inherit;
+  text-decoration: none !important;
+  background-color: #ffffff;
+  border: 1px solid #d4d6d8;
+  border-top: 6px solid var(--blue-600);
+  padding: 1.25rem;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+
+  * {
+    text-decoration: none !important;
+  }
+
+  &:hover {
+    background-color: var(--gray-100);
+    border-color: var(--gray-500);
+    text-decoration: none !important;
+  }
+`;
+
+const SimpleGroupTitle = styled.h4`
+  margin: 0 0 0.75rem 0;
+  color: var(--black);
+  font-family: var(--fontFamilyHeadings);
+  font-size: 1.75rem;
+  line-height: 1;
+`;
+
+const SimpleGroupMeta = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+`;
+
+const SimpleMetaItem = styled.div`
+  color: var(--gray-700);
+  font-family: var(--fontFamily);
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+`;
+
+const SimpleGroupFooter = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  border-top: 1px solid #d4d6d8;
+  padding-top: 0.875rem;
+  padding-right: 1rem;
+`;
+
+const SimpleModified = styled.div`
+  color: var(--gray-600);
+  font-size: 0.875rem;
+`;
+
+const SimpleOpenLabel = styled.div`
+  align-items: center;
+  background-color: var(--blue-600);
+  border: 2px solid var(--blue-600);
+  color: var(--white);
+  display: inline-flex;
+  flex-shrink: 0;
+  font-family: var(--fontFamilyHeadings);
+  font-size: 0.8125rem;
+  font-weight: 700;
+  gap: 0.5rem;
+  line-height: 1;
+  margin-left: auto;
+  margin-right: 1rem;
+  min-height: 2.5rem;
+  padding: 0.75rem 1rem;
+  text-decoration: none !important;
+  text-transform: uppercase;
+  transform: none !important;
+  transition: none !important;
+  white-space: nowrap;
+
+  &::after {
+    content: '→';
+    font-size: 1rem;
+    line-height: 1;
+  }
+
+  &:hover,
+  &:focus,
+  &:active {
+    background-color: var(--blue-600);
+    border-color: var(--blue-600);
+    color: var(--white);
+    text-decoration: none !important;
+  }
 `;
 
 // TimeAgo component for displaying relative time from a date string
@@ -130,7 +258,10 @@ const convertToStandardFormat = (
   }));
 };
 
-export const UserGroupsList = ({ userGroups: propUserGroups }: UserGroupsListProps) => {
+export const UserGroupsList = ({
+  userGroups: propUserGroups,
+  variant = 'hero',
+}: UserGroupsListProps) => {
   const { userGroups: contextUserGroups, updateUserGroups } = useContext(Context);
   const { confirm } = Modal;
   const [isModalVisible, setIsModalVisible] = useState(false);
@@ -296,19 +427,43 @@ export const UserGroupsList = ({ userGroups: propUserGroups }: UserGroupsListPro
           
           return (
             <GroupCard key={group.id}>
-              <HeroCard
-                title={group.name}
-                // timeAgo={TimeAgo({ date: group.modified_at })}
-                bgImage={group.attachment || undefined}
-                // menuItems={menuItems}
-                url={getGroupUrl()}
-              >
-                <InfoSection>
-                  {renderCollaboratorCount(group)}
-                  {renderSignalCount(group)}
-                </InfoSection>
-                {renderGroupSignals(group)}
-              </HeroCard>
+              {variant === 'simple' ? (
+                <SimpleGroupCard href={getGroupUrl()}>
+                  <SimpleGroupTitle>{group.name}</SimpleGroupTitle>
+                  <SimpleGroupMeta>
+                    <SimpleMetaItem>
+                      <UserOutlined /> {group.user_ids?.length || 0}{' '}
+                      {(group.user_ids?.length || 0) === 1
+                        ? 'Collaborator'
+                        : 'Collaborators'}
+                    </SimpleMetaItem>
+                    <SimpleMetaItem>
+                      <FileTextOutlined /> {group.signal_ids?.length || 0}{' '}
+                      {(group.signal_ids?.length || 0) === 1
+                        ? 'Signal'
+                        : 'Signals'}
+                    </SimpleMetaItem>
+                  </SimpleGroupMeta>
+                  <SimpleGroupFooter>
+                    <SimpleModified>
+                      {TimeAgo({ date: group.modified_at }) || 'Recently updated'}
+                    </SimpleModified>
+                    <SimpleOpenLabel>Open Sprint</SimpleOpenLabel>
+                  </SimpleGroupFooter>
+                </SimpleGroupCard>
+              ) : (
+                <HeroCard
+                  title={group.name}
+                  bgImage={group.attachment || undefined}
+                  url={getGroupUrl()}
+                >
+                  <InfoSection>
+                    {renderCollaboratorCount(group)}
+                    {renderSignalCount(group)}
+                  </InfoSection>
+                  {renderGroupSignals(group)}
+                </HeroCard>
+              )}
             </GroupCard>
           );
         })}

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -328,7 +328,6 @@ export const WEB_ADDRESS = 'https://signals.data.undp.org';
 
 export const API_BASEURL = process.env.VITE_API_BASEURL;
 export const CLIENT_ID = process.env.VITE_CLIENT_ID;
-export const CLIENT_SECRET = process.env.VITE_CLIENT_SECRET;
 export const AUTHORITY = process.env.VITE_AUTHORITY;
 
 

--- a/src/MainBody.tsx
+++ b/src/MainBody.tsx
@@ -193,20 +193,16 @@ function MainBody() {
       <AuthenticatedTemplate>
         <RaggleProvider
           chatEmbedUrl='https://ftss-chatbot.vercel.app'
+          bubbleSize={64}
           chatBubbleContent={() => (
             <button
               type='button'
               className='chat-bubble'
-              style={{
-                backgroundColor: 'var(--blue-600)',
-                width: '100%',
-                height: '100%',
-                cursor: 'pointer',
-                transition: 'all 0.3s ease',
-              }}
               aria-label='Chat with Echo, AI assistant'
             >
-              <ChatIcon />
+              <span className='chat-bubble-icon' aria-hidden='true'>
+                <ChatIcon />
+              </span>
             </button>
           )}
         >

--- a/src/MainBody.tsx
+++ b/src/MainBody.tsx
@@ -343,24 +343,21 @@ function MainBody() {
           >
             Download selected
             {cardsToPrint.filter(d => d.type === 'signal').length > 0
-              ? ` ${
-                  cardsToPrint.filter(d => d.type === 'signal').length
-                } signal${
-                  cardsToPrint.filter(d => d.type === 'signal').length === 1
-                    ? ''
-                    : 's'
-                }`
+              ? ` ${cardsToPrint.filter(d => d.type === 'signal').length
+              } signal${cardsToPrint.filter(d => d.type === 'signal').length === 1
+                ? ''
+                : 's'
+              }`
               : ''}
             {cardsToPrint.filter(d => d.type === 'signal').length > 0 &&
-            cardsToPrint.filter(d => d.type === 'trend').length > 0
+              cardsToPrint.filter(d => d.type === 'trend').length > 0
               ? ' and'
               : ''}
             {cardsToPrint.filter(d => d.type === 'trend').length > 0
-              ? ` ${cardsToPrint.filter(d => d.type === 'trend').length} trend${
-                  cardsToPrint.filter(d => d.type === 'trend').length === 1
-                    ? ''
-                    : 's'
-                }`
+              ? ` ${cardsToPrint.filter(d => d.type === 'trend').length} trend${cardsToPrint.filter(d => d.type === 'trend').length === 1
+                ? ''
+                : 's'
+              }`
               : ''}{' '}
             as PDF
           </button>
@@ -391,7 +388,7 @@ function MainBody() {
                 if (d.type === 'signal') {
                   const s =
                     signalsForPrinting[
-                      signalsForPrinting.findIndex(el => `${el.id}` === d.id)
+                    signalsForPrinting.findIndex(el => `${el.id}` === d.id)
                     ];
                   return (
                     <div
@@ -453,7 +450,7 @@ function MainBody() {
                 }
                 const s =
                   trendsForPrinting[
-                    trendsForPrinting.findIndex(el => `${el.id}` === d.id)
+                  trendsForPrinting.findIndex(el => `${el.id}` === d.id)
                   ];
                 return (
                   <div
@@ -521,23 +518,23 @@ function MainBody() {
                     pages={cardsToPrint.map(d =>
                       d.type === 'signal'
                         ? {
-                            type: 'signal',
-                            mode: d.mode,
-                            data: signalsForPrinting[
-                              signalsForPrinting.findIndex(
-                                el => `${el.id}` === d.id,
-                              )
-                            ],
-                          }
+                          type: 'signal',
+                          mode: d.mode,
+                          data: signalsForPrinting[
+                            signalsForPrinting.findIndex(
+                              el => `${el.id}` === d.id,
+                            )
+                          ],
+                        }
                         : {
-                            type: 'trend',
-                            mode: d.mode,
-                            data: trendsForPrinting[
-                              trendsForPrinting.findIndex(
-                                el => `${el.id}` === d.id,
-                              )
-                            ],
-                          },
+                          type: 'trend',
+                          mode: d.mode,
+                          data: trendsForPrinting[
+                            trendsForPrinting.findIndex(
+                              el => `${el.id}` === d.id,
+                            )
+                          ],
+                        },
                     )}
                     connectedSignalsForTrendsForPrinting={
                       connectedSignalsForTrendsForPrinting

--- a/src/MyDrafts/index.tsx
+++ b/src/MyDrafts/index.tsx
@@ -140,7 +140,7 @@ export function MyDrafts() {
                 </h5>
               )}
             </div>
-            <div className='flex-div flex-hor-align-center margin-top-07'>
+            <div className='flex-div flex-hor-align-center margin-top-07 undp-pagination-shell'>
               <Pagination
                 className='undp-pagination'
                 onChange={e => {

--- a/src/MyFavorites/index.tsx
+++ b/src/MyFavorites/index.tsx
@@ -25,7 +25,7 @@ export function MyFavorites() {
 
   return (
     <div
-      className='margin-top-13 padding-top-09 margin-bottom-09'
+      className='margin-bottom-09'
       style={{ paddingLeft: '1rem', paddingRight: '1rem' }}
     >
       <AuthenticatedTemplate>

--- a/src/MyFavorites/index.tsx
+++ b/src/MyFavorites/index.tsx
@@ -2,14 +2,18 @@ import {
   AuthenticatedTemplate,
   UnauthenticatedTemplate,
 } from '@azure/msal-react';
-import { useContext } from 'react';
+import { Pagination } from 'antd';
+import type { PaginationProps } from 'antd';
+import { useContext, useState } from 'react';
 import { SignInButton } from '../Components/SignInButton';
-import { SignalsList } from '../Components/SignalViews';
+import { SignalCard } from '../Components/SignalCard';
 import Context from '../Context/Context';
 import { useFavorites } from '../Hooks/useFavorites';
 
 export function MyFavorites() {
   const { updateSignalList } = useContext(Context);
+  const [paginationValue, setPaginationValue] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
 
   const {
     data: favoriteSignals,
@@ -22,6 +26,18 @@ export function MyFavorites() {
       updateSignalList(data);
     },
   });
+
+  const onShowSizeChange: PaginationProps['onShowSizeChange'] = (
+    _current,
+    size,
+  ) => {
+    setPageSize(size);
+  };
+
+  const paginatedSignals = (favoriteSignals || []).slice(
+    (paginationValue - 1) * pageSize,
+    paginationValue * pageSize,
+  );
 
   return (
     <div
@@ -36,15 +52,53 @@ export function MyFavorites() {
           >
             {error instanceof Error ? error.message : 'An error occurred while fetching favorites'}
           </p>
+        ) : isLoading ? (
+          <div className='undp-loader-container'>
+            <div className='undp-loader' />
+          </div>
         ) : (
-          <SignalsList
-            signals={favoriteSignals || []}
-            title="My Favorites"
-            loading={isLoading}
-            emptyStateMessage="You haven't added any favorite signals yet."
-            showViewToggle={true}
-            showPagination={true}
-          />
+          <div>
+            <h3 className='undp-typography margin-top-05'>My Favorites</h3>
+            <div className='flex-div flex-wrap listing'>
+              {favoriteSignals && favoriteSignals.length > 0 ? (
+                paginatedSignals.map(signal => (
+                  <SignalCard
+                    data={signal}
+                    key={signal.id}
+                  />
+                ))
+              ) : (
+                <h5
+                  className='undp-typography bold'
+                  style={{
+                    backgroundColor: 'var(--gray-200)',
+                    textAlign: 'center',
+                    padding: 'var(--spacing-07)',
+                    width: 'calc(100% - 4rem)',
+                    border: '1px solid var(--gray-400)',
+                  }}
+                >
+                  You haven&apos;t added any favorite signals yet.
+                </h5>
+              )}
+            </div>
+            {favoriteSignals && favoriteSignals.length > 0 ? (
+              <div className='flex-div flex-hor-align-center margin-top-07 undp-pagination-shell'>
+                <Pagination
+                  className='undp-pagination'
+                  onChange={e => {
+                    setPaginationValue(e);
+                  }}
+                  defaultCurrent={1}
+                  current={paginationValue}
+                  total={favoriteSignals.length}
+                  pageSize={pageSize}
+                  showSizeChanger
+                  onShowSizeChange={onShowSizeChange}
+                />
+              </div>
+            ) : null}
+          </div>
         )}
       </AuthenticatedTemplate>
       <UnauthenticatedTemplate>

--- a/src/MyProjects/index.tsx
+++ b/src/MyProjects/index.tsx
@@ -83,13 +83,13 @@ export function MyProjects() {
 
   return (
     <div
-      className='margin-top-13 padding-top-09 margin-bottom-09'
+      className='margin-bottom-09'
       style={{ paddingLeft: '1rem', paddingRight: '1rem' }}
     >
       <AuthenticatedTemplate>
         {signalList ? (
           <div>
-            <h3 className='undp-typography margin-top-05'>Projects</h3>
+            <h3 className='undp-typography margin-top-00 margin-bottom-05'>Projects</h3>
             <div className='flex-div flex-wrap listing'>
               {signalList.length > 0 ? (
                 <ProjectsCardList />

--- a/src/MySprints/index.tsx
+++ b/src/MySprints/index.tsx
@@ -234,6 +234,7 @@ export function MySprints() {
             <UserGroupsList 
               userGroups={paginatedGroups} 
               onView={handleViewGroup} 
+              variant='simple'
             />
             
             {totalGroups > groupsPageSize && (

--- a/src/Pages/DigestPage.test.tsx
+++ b/src/Pages/DigestPage.test.tsx
@@ -1,29 +1,29 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import Context from '../Context/Context';
-import type { ChoicesDataType, CtxDataType } from '../Types';
-import DigestPage from './DigestPage';
+import Context from '@/Context/Context';
+import type { ChoicesDataType, CtxDataType } from '@/Types';
+import DigestPage from '@/Pages/DigestPage';
 
 const mockGetChoices = vi.fn();
 const mockSearchSignals = vi.fn();
 
-vi.mock('../API/choicesCalls', () => ({
+vi.mock('@/API/choicesCalls', () => ({
   getChoices: () => mockGetChoices(),
 }));
 
-vi.mock('../API/signalsCall', () => ({
+vi.mock('@/API/signalsCall', () => ({
   searchSignals: (...args: unknown[]) => mockSearchSignals(...args),
   triggerDigestEmail: vi.fn(),
 }));
 
-vi.mock('../Components/SignalViews/SignalGridView', () => ({
+vi.mock('@/Components/SignalViews/SignalGridView', () => ({
   SignalGridView: ({ signals }: { signals: Array<{ id: number }> }) => (
     <div data-testid="signal-grid">Grid count: {signals.length}</div>
   ),
 }));
 
-vi.mock('../Components/SignalViews/SignalHorizontalView', () => ({
+vi.mock('@/Components/SignalViews/SignalHorizontalView', () => ({
   SignalHorizontalView: ({ signals }: { signals: Array<{ id: number }> }) => (
     <div data-testid="signal-list">List count: {signals.length}</div>
   ),

--- a/src/Pages/DigestPage.test.tsx
+++ b/src/Pages/DigestPage.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Context from '../Context/Context';
+import type { ChoicesDataType, CtxDataType } from '../Types';
+import DigestPage from './DigestPage';
+
+const mockGetChoices = vi.fn();
+const mockSearchSignals = vi.fn();
+
+vi.mock('../API/choicesCalls', () => ({
+  getChoices: () => mockGetChoices(),
+}));
+
+vi.mock('../API/signalsCall', () => ({
+  searchSignals: (...args: unknown[]) => mockSearchSignals(...args),
+  triggerDigestEmail: vi.fn(),
+}));
+
+vi.mock('../Components/SignalViews/SignalGridView', () => ({
+  SignalGridView: ({ signals }: { signals: Array<{ id: number }> }) => (
+    <div data-testid="signal-grid">Grid count: {signals.length}</div>
+  ),
+}));
+
+vi.mock('../Components/SignalViews/SignalHorizontalView', () => ({
+  SignalHorizontalView: ({ signals }: { signals: Array<{ id: number }> }) => (
+    <div data-testid="signal-list">List count: {signals.length}</div>
+  ),
+}));
+
+function renderDigestPage(contextOverrides: Partial<CtxDataType> = {}) {
+  const contextValue = {
+    isAdmin: true,
+    userName: 'reviewer@example.com',
+    ...contextOverrides,
+  } as CtxDataType;
+
+  return render(
+    <Context.Provider value={contextValue}>
+      <MemoryRouter
+        initialEntries={['/digest']}
+        future={{
+          v7_startTransition: true,
+          v7_relativeSplatPath: true,
+        }}
+      >
+        <Routes>
+          <Route path="/" element={<div>Home page</div>} />
+          <Route path="/digest" element={<DigestPage />} />
+        </Routes>
+      </MemoryRouter>
+    </Context.Provider>,
+  );
+}
+
+describe('DigestPage', () => {
+  beforeEach(() => {
+    mockGetChoices.mockReset();
+    mockSearchSignals.mockReset();
+  });
+
+  it('redirects non-admin users without loading page data', async () => {
+    renderDigestPage({ isAdmin: false });
+
+    await waitFor(() => {
+      expect(screen.getByText('Home page')).toBeInTheDocument();
+    });
+
+    expect(mockGetChoices).not.toHaveBeenCalled();
+    expect(mockSearchSignals).not.toHaveBeenCalled();
+  });
+
+  it('loads choices and draft signals for admins', async () => {
+    const choices = {
+      steep: ['Economic'],
+      signature: ['Governance'],
+      location: ['Kenya'],
+      goal: ['Goal 1'],
+    } as ChoicesDataType;
+
+    mockGetChoices.mockResolvedValueOnce(choices);
+    mockSearchSignals.mockResolvedValueOnce({
+      current_page: 1,
+      per_page: 20,
+      total_pages: 1,
+      total_count: 2,
+      data: [{ id: 1 }, { id: 2 }],
+    });
+
+    renderDigestPage();
+
+    await waitFor(() => {
+      expect(mockGetChoices).toHaveBeenCalledTimes(1);
+      expect(mockSearchSignals).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockSearchSignals).toHaveBeenCalledWith({
+      statuses: ['New'],
+      page: 1,
+      per_page: 20,
+      order_by: 'created_at',
+      direction: 'desc',
+      query: '',
+    });
+    expect(
+      screen.getByText('2 draft signals pending curator review'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('signal-grid')).toHaveTextContent('Grid count: 2');
+  });
+});

--- a/src/Pages/DigestPage.tsx
+++ b/src/Pages/DigestPage.tsx
@@ -73,14 +73,18 @@ export default function DigestPage() {
   const [tempFilters, setTempFilters] = useState<SignalFiltersType>({});
   const [choices, setChoices] = useState<ChoicesDataType | null>(null);
 
-  // Redirect if not admin
-  if (!isAdmin) {
-    navigate('/');
-    return null;
-  }
+  useEffect(() => {
+    if (!isAdmin) {
+      navigate('/');
+    }
+  }, [isAdmin, navigate]);
 
   // Load choices for filters
   useEffect(() => {
+    if (!isAdmin) {
+      return;
+    }
+
     getChoices()
       .then(data => setChoices(data))
       .catch(error => {
@@ -114,8 +118,12 @@ export default function DigestPage() {
   };
 
   useEffect(() => {
+    if (!isAdmin) {
+      return;
+    }
+
     loadSignals(1);
-  }, [searchQuery, sortBy, filters]);
+  }, [filters, isAdmin, searchQuery, sortBy]);
 
   const handleSearch = (value: string) => {
     setSearchQuery(value);
@@ -198,6 +206,10 @@ export default function DigestPage() {
       setEmailLoading(false);
     }
   };
+
+  if (!isAdmin) {
+    return null;
+  }
 
   return (
     <div className="undp-container" style={{ padding: '2rem' }}>
@@ -319,8 +331,9 @@ export default function DigestPage() {
       >
         <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
           <div>
-            <label className="undp-form-label">Primary STEEP+V</label>
+            <Typography.Text className="undp-form-label">Primary STEEP+V</Typography.Text>
             <Select
+              aria-label="Primary STEEP+V"
               value={tempFilters.steep_primary}
               onChange={value => setTempFilters({...tempFilters, steep_primary: value})}
               style={{ width: '100%' }}
@@ -334,8 +347,9 @@ export default function DigestPage() {
           </div>
           
           <div>
-            <label className="undp-form-label">Primary Signature Solution/Enabler</label>
+            <Typography.Text className="undp-form-label">Primary Signature Solution/Enabler</Typography.Text>
             <Select
+              aria-label="Primary Signature Solution or Enabler"
               value={tempFilters.signature_primary}
               onChange={value => setTempFilters({...tempFilters, signature_primary: value})}
               style={{ width: '100%' }}
@@ -349,8 +363,9 @@ export default function DigestPage() {
           </div>
           
           <div>
-            <label className="undp-form-label">Location</label>
+            <Typography.Text className="undp-form-label">Location</Typography.Text>
             <Select
+              aria-label="Location"
               value={tempFilters.location}
               onChange={value => setTempFilters({...tempFilters, location: value})}
               style={{ width: '100%' }}
@@ -364,8 +379,9 @@ export default function DigestPage() {
           </div>
           
           <div>
-            <label className="undp-form-label">SDGs</label>
+            <Typography.Text className="undp-form-label">SDGs</Typography.Text>
             <Select
+              aria-label="SDGs"
               mode="multiple"
               value={tempFilters.sdgs}
               onChange={value => setTempFilters({...tempFilters, sdgs: value})}
@@ -403,8 +419,9 @@ export default function DigestPage() {
         </div>
         
         <div style={{ marginTop: '1.5rem' }}>
-          <label className="undp-form-label">Recipients</label>
+          <Typography.Text className="undp-form-label">Recipients</Typography.Text>
           <Select
+            aria-label="Recipients"
             mode="tags"
             style={{ width: '100%' }}
             placeholder="Enter email addresses"
@@ -418,8 +435,9 @@ export default function DigestPage() {
         </div>
 
         <div style={{ marginTop: '1rem' }}>
-          <label className="undp-form-label">Days to Include</label>
+          <Typography.Text className="undp-form-label">Days to Include</Typography.Text>
           <InputNumber
+            aria-label="Days to Include"
             min={1}
             max={30}
             value={days}

--- a/src/Pages/DigestPage.tsx
+++ b/src/Pages/DigestPage.tsx
@@ -1,9 +1,9 @@
 import { useContext, useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import Context from '../Context/Context';
-import { triggerDigestEmail, searchSignals } from '../API/signalsCall';
-import { SignalGridView } from '../Components/SignalViews/SignalGridView';
-import { SignalHorizontalView } from '../Components/SignalViews/SignalHorizontalView';
+import Context from '@/Context/Context';
+import { triggerDigestEmail, searchSignals } from '@/API/signalsCall';
+import { SignalGridView } from '@/Components/SignalViews/SignalGridView';
+import { SignalHorizontalView } from '@/Components/SignalViews/SignalHorizontalView';
 import { 
   Button, 
   Alert, 
@@ -28,9 +28,9 @@ import {
   SortAscendingOutlined,
   ClearOutlined
 } from '@ant-design/icons';
-import { SignalDataType, ChoicesDataType } from '../Types';
-import { CREATED_FOR, SIGNAL_ORDER_BY_OPTIONS } from '../Constants';
-import { getChoices } from '../API/choicesCalls';
+import { SignalDataType, ChoicesDataType } from '@/Types';
+import { CREATED_FOR, SIGNAL_ORDER_BY_OPTIONS } from '@/Constants';
+import { getChoices } from '@/API/choicesCalls';
 
 const { Option } = Select;
 const { Search } = Input;

--- a/src/Signals/index.tsx
+++ b/src/Signals/index.tsx
@@ -51,7 +51,7 @@ export function SignalsListing() {
   });
   const [showFilterModal, setShowFilterModal] = useState(false);
   return (
-    <>
+    <div className='signals-page'>
       <HeroImageEl className='undp-hero-image'>
         <div className='max-width'>
           <h1 className='undp-typography'>
@@ -240,7 +240,8 @@ export function SignalsListing() {
       ) : null}
       <AllSignals view={viewType} />
       <Modal
-        className='undp-modal'
+        className='undp-modal signals-filter-modal'
+        rootClassName='signals-filter-modal'
         open={showFilterModal}
         onCancel={() => {
           setTempFilters(signalFilters);
@@ -683,7 +684,7 @@ export function SignalsListing() {
           Apply Filters
         </button>
       </Modal>
-    </>
+    </div>
   );
 }
 
@@ -691,7 +692,7 @@ export function ArchivedSignalsListing() {
   const { role } = useContext(Context);
   const [viewType, setViewType] = useState<'cardView' | 'listView'>('cardView');
   return (
-    <>
+    <div className='signals-page'>
       <HeroImageEl className='undp-hero-image'>
         <div className='max-width'>
           <h1 className='undp-typography'>
@@ -740,6 +741,6 @@ export function ArchivedSignalsListing() {
       <UnauthenticatedTemplate>
         <SignInButton buttonText='Sign In to View This Page' />
       </UnauthenticatedTemplate>
-    </>
+    </div>
   );
 }

--- a/src/SprintPage.tsx
+++ b/src/SprintPage.tsx
@@ -18,7 +18,6 @@ import {
   Button,
   InputRef
 } from 'antd';
-import UNDPButton from "./Components/button"
 import {
   CheckOutlined,
   CloseOutlined,
@@ -67,10 +66,6 @@ const HeaderContainer = styled.div`
   justify-content: space-between;
   align-items: center;
   margin-bottom: 2rem;
-`;
-
-const BackButton = styled(Button)`
-  display: inline-block;
 `;
 
 const HeaderContent = styled.div`
@@ -320,9 +315,13 @@ export function SprintPage() {
       {contextHolder}
       <AuthenticatedTemplate>
         <BackButtonContainer>
-          <BackButton type="default" onClick={handleBack}>
+          <button
+            className='undp-button button-tertiary'
+            type='button'
+            onClick={handleBack}
+          >
             ← Back to Sprints
-          </BackButton>
+          </button>
         </BackButtonContainer>
 
         <HeaderContainer>
@@ -353,15 +352,14 @@ export function SprintPage() {
                   disabledTooltip="Only sprint admins or application admins can edit or delete this sprint"
                 />
               </div>
-              <a href="/signals">
-              <UNDPButton 
-                  icon={<PlusOutlined />}
-                  onClick={() => setIsSignalSearchVisible(true)}
-                  style={{ backgroundColor: '#006EB5' }}
-                >
-                  Add Signals
-              </UNDPButton>
-              </a>
+              <button
+                className='undp-button button-secondary'
+                type='button'
+                onClick={() => setIsSignalSearchVisible(true)}
+              >
+                <PlusOutlined />
+                Add Signals
+              </button>
             </div>
           </HeaderContent>
         </HeaderContainer>

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -11,3 +11,40 @@ afterEach(() => {
   cleanup();
 });
 
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => false,
+  }),
+});
+
+class ResizeObserverMock {
+  observe() {
+    return undefined;
+  }
+
+  unobserve() {
+    return undefined;
+  }
+
+  disconnect() {
+    return undefined;
+  }
+}
+
+Object.defineProperty(window, 'ResizeObserver', {
+  writable: true,
+  value: ResizeObserverMock,
+});
+
+Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+  writable: true,
+  value: () => undefined,
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,11 +15,16 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": [
     ".eslintrc.json",
     "vite.config.ts",
+    "vitest.config.ts",
     "src"
   ],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -3,7 +3,11 @@
     "composite": true,
     "module": "ESNext",
     "moduleResolution": "Node",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath, URL } from 'node:url';
 import react from '@vitejs/plugin-react';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable no-unused-vars */
@@ -7,6 +8,11 @@ export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   return {
     plugins: [react()],
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+      },
+    },
     define: {
       'process.env': env,
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  cacheDir: '/tmp/ftss-fe-vitest-cache',
   test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/setupTests.ts'],
     include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     exclude: ['**/node_modules/**', '**/dist/**', '**/cypress/**', '**/.{idea,git,cache,output,temp}/**', '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*'],
     testTimeout: 10000, 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,13 @@
+import { fileURLToPath, URL } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   cacheDir: '/tmp/ftss-fe-vitest-cache',
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
  ## Summary

  These two commits focused on frontend
  maintainability and correctness rather than feature
  expansion.

  The first commit standardized frontend imports
  around the @/* alias and updated Vite/Vitest/
  TypeScript config so the alias works consistently in
  app code and tests. The second commit tightened
  admin-only access handling, improved accessibility
  for the digest and signal extraction flows, removed
  a frontend-only client secret reference, and added
  targeted automated tests around admin routing,
  digest behavior, and signal search API params.

  ## Changes Made

  - Added @/* path alias support in tsconfig.json,
    tsconfig.node.json, vite.config.ts, and
    vitest.config.ts.
  - Updated DigestPage and its tests to use alias-
    based imports.
  - Refactored DigestPage admin protection so
    redirects happen inside useEffect, and non-admin
    users do not trigger protected page data loading.
  - Added accessibility labels to DigestPage filter
    and recipient controls.
  - Updated SignalEntryFormEl validation links from
    clickable <li> content to real <button> elements
    for better semantics and keyboard accessibility.
  - Reworked SmartExtractModal to use dialog semantics
    (role="dialog", aria-modal) and an explicit close-
    overlay button.
  - Removed CLIENT_SECRET from frontend auth/constants
    usage.
  - Removed dormant PropTypes code from MemberSelect.
  - Added new tests for:
      - searchSignals default and optional params
      - AdminRoute access behavior
      - DigestPage admin redirect and data-loading
        behavior
  - Added browser/test environment mocks in
    setupTests.ts for matchMedia, ResizeObserver, and
    scrollIntoView.
  - Moved Vitest configuration out of package.json and
    into vitest.config.ts.
  - Cleaned .env.example, ESLint config, and related
    docs/config files.

  ## Technical Details

  - Architecture changes:
      - Introduced a repo-wide import alias: @ -> src.
      - Tightened route/data access flow by preventing
        non-admin digest fetches before redirect.
  - New libraries/dependencies:
      - None added.
  - API changes:
      - No backend contract changes.
      - Added test coverage for searchSignals()
        request param construction.
  - Auth/config changes:
      - Removed frontend CLIENT_SECRET usage from
        AuthConfig.ts and Constants.ts.
      - Simplified .env.example to the variables
        actually needed by the frontend.
  - Database changes:
      - None.
  - Performance considerations:
      - Minor improvement from skipping digest choice/
        signal fetches for unauthorized users.
      - No material rendering or bundle-size change
        beyond config cleanup.

  ## Testing

  - Unit tests added/updated:
      - src/API/signalsCall.test.ts
      - src/Components/AdminRoute.test.tsx
      - src/Pages/DigestPage.test.tsx
      - Existing digest test updated for alias imports
        in b001563
  - Manual testing performed:
      - Not explicitly captured in the commit
        contents.
  - Current validation run:
      - npm test -- --run passed: 3 test files, 6
        tests
      - npm run type-check passed
  - Edge cases covered:
      - Non-admin access to digest page
      - Digest page avoiding protected fetches for
        unauthorized users
      - Default vs optional search param handling in
        searchSignals
      - Browser API gaps in jsdom via test setup mocks

  ## Screenshots/Videos

  N/A. These commits are primarily config, auth-guard,
  accessibility, and test-coverage changes.

  ## Checklist

  - [x] My code follows the style guidelines of this
    project.
  - [x] I have performed a self-review of my code.
  - [x] I have commented my code, particularly in
    hard-to-understand areas.
  - [x] I have made corresponding changes to the
    documentation (if applicable).
  - [x] My changes generate no new warnings or errors.
  - [x] I have added tests that prove my change is
    effective or that my feature works.
  - [x] Any dependent changes have been merged and
    published.
  - [x] I have updated relevant packages in
    package.json (if applicable).

  ## Deployment Notes

  - No database migrations or backend deployments are
    required.
  - Ensure frontend environment variables still
    provide:
      - VITE_CLIENT_ID
      - VITE_AUTHORITY
      - VITE_API_BASEURL
  - Frontend CLIENT_SECRET usage was removed and
    should not be reintroduced into browser-side
    config.

  ## Additional Notes

  - No new dependencies were introduced.
  - The test suite now relies on shared jsdom/browser
    mocks in src/setupTests.ts.
