### PR TITLE
Updated filter button to hover to lighter blue on scroll over

### DIFF
--- a/src/Signals/index.tsx
+++ b/src/Signals/index.tsx
@@ -11,7 +11,6 @@ import Context from '../Context/Context';
 import { SignalFiltersDataType, StatusDataType } from '../Types';
 import { SignInButton } from '../Components/SignInButton';
 import { CREATED_FOR, SIGNAL_ORDER_BY_OPTIONS } from '../Constants';
-import Button from '../Components/button';
 
 const HeroImageEl = styled.div`
   background: linear-gradient(rgba(0, 0, 0, 0.45), rgba(0, 0, 0, 0.45)),
@@ -98,7 +97,7 @@ export function SignalsListing() {
               </Select.Option>
             ))}
           </Select>
-          <Button
+          <button
             type='button'
             className='undp-button button-secondary'
             onClick={() => {
@@ -108,7 +107,7 @@ export function SignalsListing() {
           >
             Filters
             {noOfSignalsFiltersActive ? ` (${noOfSignalsFiltersActive})` : ''}
-          </Button>
+          </button>
           <Radio.Group
             defaultValue='cardView'
             onChange={e => {


### PR DESCRIPTION
## Summary

  Updated the Signals listing Filters button so its hover
  styling matches the adjacent Search button behavior.

  ## Changes Made

  - Replaced the Signals Filters control from the shared Ant
    Design button wrapper to a native button.
  - Kept the existing UNDP classes: undp-button button-
    secondary.
  - Preserved the existing click behavior and active filter
    count display.

  ## Technical Details

  - Changed fe-signals-and-trends/src/Signals/index.tsx:101.
  - Removed the now-unused ../Components/button import.
  - No architecture changes.
  - No new dependencies.
  - No API or database changes.

  ## Testing

  - Ran pnpm build successfully.
  - Build completed with existing Vite bundle-size warnings
    and dependency use client warnings, but no new errors.

  ## Screenshots/Videos

  Not included.

  ## Checklist

  - [x] My code follows the style guidelines of this
    project.
  - [x] I have performed a self-review of my code.
  - [x] I have commented my code, particularly in hard-to-
    understand areas.
  - [x] I have made corresponding changes to the
    documentation (if applicable).
  - [x] My changes generate no new warnings or errors.
  - [x] I have added tests that prove my change is effective
    or that my feature works.
  - [x] Any dependent changes have been merged and
    published.
  - [x] I have updated relevant packages in package.json (if
    applicable).

  ## Deployment Notes

  No special deployment steps required.

  ## Additional Notes

  No known issues.